### PR TITLE
Add audio pass-through component

### DIFF
--- a/include/MainComponent.h
+++ b/include/MainComponent.h
@@ -15,5 +15,6 @@ public:
     void resized() override;
 
 private:
+    juce::AudioDeviceSelectorComponent deviceSelector;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };

--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -1,8 +1,14 @@
 #include "MainComponent.h"
 
 MainComponent::MainComponent()
+    : deviceSelector(deviceManager, 1, 2, 1, 2, false, false, true, false)
 {
-    setAudioChannels(0, 2); // no inputs, two outputs
+    addAndMakeVisible(deviceSelector);
+
+    // request one input and two output channels by default
+    setAudioChannels(2, 2);
+
+    setSize(600, 400);
 }
 
 MainComponent::~MainComponent()
@@ -12,15 +18,20 @@ MainComponent::~MainComponent()
 
 void MainComponent::prepareToPlay(int /*samplesPerBlockExpected*/, double /*sampleRate*/)
 {
+    // nothing to prepare for this simple pass-through example
 }
 
 void MainComponent::getNextAudioBlock(const juce::AudioSourceChannelInfo& bufferToFill)
 {
-    bufferToFill.clearActiveBufferRegion();
+    // The buffer provided by AudioSourcePlayer already contains the microphone
+    // input copied into the output channels. Leaving it untouched passes the
+    // audio through without additional latency.
+    juce::ignoreUnused(bufferToFill);
 }
 
 void MainComponent::releaseResources()
 {
+    // nothing to release
 }
 
 void MainComponent::paint(juce::Graphics& g)
@@ -30,4 +41,5 @@ void MainComponent::paint(juce::Graphics& g)
 
 void MainComponent::resized()
 {
+    deviceSelector.setBounds(getLocalBounds());
 }


### PR DESCRIPTION
## Summary
- expose `AudioDeviceSelectorComponent` for selecting microphone and device settings
- set up audio with input channels and pass input directly to output

## Testing
- `cmake .. && cmake --build .` *(fails: `gtk/gtk.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d71ace5d48323bce27ec4ee26d0df