### PR TITLE
Implement macOS microphone permission request

### DIFF
--- a/include/mac/MacPermissions.h
+++ b/include/mac/MacPermissions.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace MacPermissions
+{
+    void requestMicrophoneAccessIfNeeded();
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,20 +2,25 @@ set(SOURCE_FILES
     Main.cpp
     MainComponent.cpp
     NoiseCanceller.cpp
+    MacPermissions_mac.mm
 )
 
 set(HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/../include/MainComponent.h
     ${CMAKE_CURRENT_LIST_DIR}/../include/NoiseCanceller.h
+    ${CMAKE_CURRENT_LIST_DIR}/../include/mac/MacPermissions.h
 )
 
 juce_add_gui_app(NoiseSuppressor
-    PRODUCT_NAME "NoiseSuppressor")
+    PRODUCT_NAME "NoiseSuppressor"
+    MICROPHONE_PERMISSION_ENABLED TRUE
+    MICROPHONE_PERMISSION_TEXT "NoiseSuppressor requires microphone access to process audio")
 
 target_sources(NoiseSuppressor PRIVATE ${SOURCE_FILES})
 
 target_include_directories(NoiseSuppressor PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../include
+    ${CMAKE_CURRENT_LIST_DIR}/../include/mac
 )
 
 target_link_libraries(NoiseSuppressor PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,3 +27,9 @@ target_link_libraries(NoiseSuppressor PRIVATE
     juce::juce_gui_extra
     juce::juce_audio_utils
 )
+
+if(APPLE)
+    target_link_libraries(NoiseSuppressor PRIVATE
+        "-framework AVFoundation"
+    )
+endif()

--- a/src/MacPermissions_mac.mm
+++ b/src/MacPermissions_mac.mm
@@ -1,0 +1,18 @@
+#include "../include/mac/MacPermissions.h"
+#include <juce_core/system/juce_TargetPlatform.h>
+
+#if JUCE_MAC
+ #import <AVFoundation/AVFoundation.h>
+
+void MacPermissions::requestMicrophoneAccessIfNeeded()
+{
+    if (@available(macOS 10.14, *))
+    {
+        auto status = [AVCaptureDevice authorizationStatusForMediaType: AVMediaTypeAudio];
+        if (status == AVAuthorizationStatusNotDetermined)
+            [AVCaptureDevice requestAccessForMediaType: AVMediaTypeAudio completionHandler: ^(BOOL){ }];
+    }
+}
+#else
+void MacPermissions::requestMicrophoneAccessIfNeeded() {}
+#endif

--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -1,4 +1,5 @@
 #include "MainComponent.h"
+#include "../include/mac/MacPermissions.h"
 
 MainComponent::MainComponent()
     : deviceSelector(deviceManager, 1, 2, 1, 2, false, false, true, false)
@@ -129,6 +130,7 @@ void MainComponent::saveSettings()
 
 void MainComponent::openAudioWithXml(const juce::String& xmlState)
 {
+    MacPermissions::requestMicrophoneAccessIfNeeded();
     auto open = [this, xmlState]
     {
         std::unique_ptr<juce::XmlElement> xml;


### PR DESCRIPTION
## Summary
- enable microphone permission in Info.plist via CMake options
- expose a helper to request microphone access on macOS
- call the permission helper when opening the audio device

## Testing
- `cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON`
- `cmake --build .` *(fails: cannot execute `cc1objplus`)*

------
https://chatgpt.com/codex/tasks/task_e_684d855b992c8323a7ada2fdc03401f3